### PR TITLE
무기 획득 시 장착 및 무기 교체 기능 추가

### DIFF
--- a/Source/BlackSpace/Animation/AnimNotify_BSWeaponEquip.cpp
+++ b/Source/BlackSpace/Animation/AnimNotify_BSWeaponEquip.cpp
@@ -1,0 +1,38 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Animation/AnimNotify_BSWeaponEquip.h"
+#include "Animation/AnimInstance.h"
+#include "GameFramework/Character.h"
+
+#include "Components/BSCombatComponent.h"
+#include "Equipments/BSWeapon.h"
+#include "BSGameplayTag.h"
+
+void UAnimNotify_BSWeaponEquip::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference)
+{
+	Super::Notify(MeshComp, Animation, EventReference);
+
+	if (ACharacter* Player = Cast<ACharacter>(MeshComp->GetOwner()))
+	{
+		if (UAnimInstance* Anim = Player->GetMesh()->GetAnimInstance())
+		{
+			if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
+			{
+				if (ABSWeapon* Weapon = CombatComp->GetMainWeapon())
+				{
+					UAnimMontage* CurrentMontage = Anim->GetCurrentActiveMontage();
+					float CurrentPosition = Anim->Montage_GetPosition(CurrentMontage);
+
+					CombatComp->ChangeWeapon();
+
+					Weapon = CombatComp->GetMainWeapon();
+
+					UAnimMontage* NewMontage = Weapon->GetMontageForTag(BSGameplayTag::Character_Action_Equip);
+					Anim->Montage_Play(NewMontage);
+					Anim->Montage_SetPosition(NewMontage, CurrentPosition);
+				}
+			}
+		}
+	}
+}

--- a/Source/BlackSpace/Animation/AnimNotify_BSWeaponEquip.h
+++ b/Source/BlackSpace/Animation/AnimNotify_BSWeaponEquip.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "GameplayTagContainer.h"
+#include "AnimNotify_BSWeaponEquip.generated.h"
+
+UCLASS()
+class BLACKSPACE_API UAnimNotify_BSWeaponEquip : public UAnimNotify
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference) override;
+};

--- a/Source/BlackSpace/Characters/BSCharacterPlayer.h
+++ b/Source/BlackSpace/Characters/BSCharacterPlayer.h
@@ -159,6 +159,7 @@ protected:
 
 private:
 	bool IsMoving() const;
+	bool CanChangeWeapon() const;
 
 private:
 	void Move(const FInputActionValue& Value);
@@ -168,6 +169,7 @@ private:
 	void ToggleInventory();
 	void TogglePlayerStatus();
 	void Interaction();
+	void ChangeWeapon();
 
 	// 공격
 	void LightAttack();

--- a/Source/BlackSpace/Components/BSCombatComponent.cpp
+++ b/Source/BlackSpace/Components/BSCombatComponent.cpp
@@ -61,10 +61,37 @@ void UBSCombatComponent::SetSecondaryWeapon(ABSWeapon* NewWeapon)
 	bHasSecondaryWeapon = true;
 
 	SecondaryWeapon = NewWeapon;
+	SecondaryWeapon->SetActorHiddenInGame(true);
 
 	if (GetOwner()->ActorHasTag(TEXT("Player")))
 	{
 		OnChangedSecondaryWeapon.Broadcast(SecondaryWeapon->GetInventoryInfo());
+	}
+}
+
+void UBSCombatComponent::ChangeWeapon()
+{
+	if (CanChangeWeapon())
+	{
+		MainWeapon->SetActorHiddenInGame(true);
+		SecondaryWeapon->SetActorHiddenInGame(false);
+
+		ABSWeapon* TempWeapon = MainWeapon;
+
+		MainWeapon = SecondaryWeapon;
+		MainWeapon->AttachToOwner(MainWeapon->GetEquipSocket());
+		MainWeapon->OnUpdateWeaponType();
+		if (GetOwner()->ActorHasTag(TEXT("Player")))
+		{
+			OnChangedMainWeapon.Broadcast(MainWeapon->GetInventoryInfo());
+		}
+
+		SecondaryWeapon = TempWeapon;
+		SecondaryWeapon->DetachToOwner();
+		if (GetOwner()->ActorHasTag(TEXT("Player")))
+		{
+			OnChangedSecondaryWeapon.Broadcast(SecondaryWeapon->GetInventoryInfo());
+		}
 	}
 }
 

--- a/Source/BlackSpace/Components/BSCombatComponent.h
+++ b/Source/BlackSpace/Components/BSCombatComponent.h
@@ -57,6 +57,8 @@ public:
 	FORCEINLINE FGameplayTag GetLastAttackType() const { return LastAttackType; }
 	FORCEINLINE void SetLastAttackType(const FGameplayTag& NewAttackType) { LastAttackType = NewAttackType; }
 
+	FORCEINLINE bool CanChangeWeapon() const { return bHasMainWeapon && bHasSecondaryWeapon; }
+
 protected:
 	virtual void BeginPlay() override;
 
@@ -66,6 +68,7 @@ public:
 public:
 	void SetWeapon(ABSWeapon* NewWeapon);
 	void SetSecondaryWeapon(ABSWeapon* NewWeapon);
+	void ChangeWeapon();
 
 	void SetUnequipMainWeapon();
 	void SetUnequipSecondaryWeapon();

--- a/Source/BlackSpace/Data/BSInputData.h
+++ b/Source/BlackSpace/Data/BSInputData.h
@@ -24,9 +24,6 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Common | Look")
 	TObjectPtr<UInputAction> IA_Look;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Common | Jump")
-	TObjectPtr<UInputAction> IA_Jump;
-
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Common | Sprint")
 	TObjectPtr<UInputAction> IA_Sprint;
 
@@ -38,6 +35,9 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Common | UI")
 	TObjectPtr<UInputAction> IA_TogglePlayerStatus;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Common | UI")
+	TObjectPtr<UInputAction> IA_ChangeWeapon;
 
 	/***********************************************/
 
@@ -57,8 +57,5 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bow | Attack")
 	TObjectPtr<UInputAction> IA_BowStringPull;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bow | Attack")
-	TObjectPtr<UInputAction> IA_BowFire;
 
 };

--- a/Source/BlackSpace/Equipments/BSEquipmentBase.cpp
+++ b/Source/BlackSpace/Equipments/BSEquipmentBase.cpp
@@ -64,3 +64,8 @@ void ABSEquipmentBase::AttachToOwner(FName SocketName)
 		}
 	}
 }
+
+void ABSEquipmentBase::DetachToOwner()
+{
+	DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
+}

--- a/Source/BlackSpace/Equipments/BSEquipmentBase.h
+++ b/Source/BlackSpace/Equipments/BSEquipmentBase.h
@@ -51,4 +51,6 @@ public:
 	virtual void UnequipItem();
 
 	virtual void AttachToOwner(FName SocketName);
+
+	virtual void DetachToOwner();
 };

--- a/Source/BlackSpace/Equipments/BSWeapon.h
+++ b/Source/BlackSpace/Equipments/BSWeapon.h
@@ -18,7 +18,7 @@ UCLASS()
 class BLACKSPACE_API ABSWeapon : public ABSEquipmentBase
 {
 	GENERATED_BODY()
-	
+
 protected:
 	UPROPERTY(EditAnywhere, Category = "Equipment | Socket")
 	FName EquipSocket;
@@ -32,7 +32,7 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "Equipment | Type")
 	EWeaponType WeaponType = EWeaponType::Sword;
 
-// Component
+	// Component
 protected:
 	UPROPERTY(VisibleAnywhere, Category = "Equipment | Component")
 	TObjectPtr<UBSCombatComponent> CombatComp;
@@ -43,7 +43,7 @@ protected:
 	UPROPERTY(VisibleAnywhere, Category = "Equipment | Component")
 	TObjectPtr<UBSWeaponCollisionComponent> SecondaryCollisionComp;
 
-// Stat
+	// Stat
 protected:
 	UPROPERTY(EditAnywhere, Category = "Equipment | Stamina")
 	TMap<FGameplayTag, float> StaminaCosts;
@@ -54,6 +54,7 @@ protected:
 public:
 	ABSWeapon();
 
+	FORCEINLINE FName GetEquipSocket() const { return EquipSocket; }
 	FORCEINLINE UBSWeaponCollisionComponent* GetCollision() const { return CollisionComp; }
 	FORCEINLINE EWeaponType GetWeaponType() const { return WeaponType; }
 

--- a/Source/BlackSpace/Items/BSPickupItem.cpp
+++ b/Source/BlackSpace/Items/BSPickupItem.cpp
@@ -7,6 +7,7 @@
 
 #include "Equipments/BSEquipmentBase.h"
 #include "Components/BSInventoryComponent.h"
+#include "Components/BSCombatComponent.h"
 #include "BSDefine.h"
 
 ABSPickupItem::ABSPickupItem()
@@ -47,9 +48,26 @@ void ABSPickupItem::Interact(AActor* Interactor)
 		{
 			if (ACharacter* Player = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0))
 			{
-				if (UBSInventoryComponent* InventoryComp = Player->GetComponentByClass<UBSInventoryComponent>())
+				if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
 				{
-					InventoryComp->AddToSlot(CDO->GetInventoryInfo());
+					if (CombatComp->GetMainWeapon() == nullptr || CombatComp->GetSecondaryWeapon() == nullptr)
+					{
+						FActorSpawnParameters Param;
+						Param.Owner = Player;
+
+						ABSEquipmentBase* Weapon = GetWorld()->SpawnActor<ABSEquipmentBase>(EquipmentClass, Player->GetActorTransform(), Param);
+						if (Weapon)
+						{
+							Weapon->EquipItem();
+						}
+					}
+					else
+					{
+						if (UBSInventoryComponent* InventoryComp = Player->GetComponentByClass<UBSInventoryComponent>())
+						{
+							InventoryComp->AddToSlot(CDO->GetInventoryInfo());
+						}
+					}
 				}
 			}
 		}

--- a/Source/BlackSpace/Items/BSPickupItemForSkeletal.cpp
+++ b/Source/BlackSpace/Items/BSPickupItemForSkeletal.cpp
@@ -7,6 +7,7 @@
 
 #include "Equipments/BSEquipmentBase.h"
 #include "Components/BSInventoryComponent.h"
+#include "Components/BSCombatComponent.h"
 #include "BSDefine.h"
 
 ABSPickupItemForSkeletal::ABSPickupItemForSkeletal()
@@ -47,9 +48,26 @@ void ABSPickupItemForSkeletal::Interact(AActor* Interactor)
 		{
 			if (ACharacter* Player = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0))
 			{
-				if (UBSInventoryComponent* InventoryComp = Player->GetComponentByClass<UBSInventoryComponent>())
+				if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
 				{
-					InventoryComp->AddToSlot(CDO->GetInventoryInfo());
+					if (CombatComp->GetMainWeapon() == nullptr || CombatComp->GetSecondaryWeapon() == nullptr)
+					{
+						FActorSpawnParameters Param;
+						Param.Owner = Player;
+
+						ABSEquipmentBase* Weapon = GetWorld()->SpawnActor<ABSEquipmentBase>(EquipmentClass, Player->GetActorTransform(), Param);
+						if (Weapon)
+						{
+							Weapon->EquipItem();
+						}
+					}
+					else
+					{
+						if (UBSInventoryComponent* InventoryComp = Player->GetComponentByClass<UBSInventoryComponent>())
+						{
+							InventoryComp->AddToSlot(CDO->GetInventoryInfo());
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## 관련 이슈 번호
#9 무기 획득 시 장칙 및 무기 교체 기능 추가

<br>


## 작업 내용 요약
- 구현한 기능이나 수정한 내용을 서술합니다.

무기 획득 시 바로 메인 무기로 장착된다.
메인 무기가 이미 존재할 시 세컨 무기로 장착되며, 두 곳 모두 무기가 있다면 인벤토리에 보관된다.

<br>

탭을 눌러 메인 무기와 보조 무기를 교체할 수 있다.

<br>


## 작업 상세 내용
- 주요 변경 사항과 설계 의도, 수정한 클래스나 시스템 구조에 대해 설명합니다.

PickupItem 클래스에서 상호작용을 할 시 무기를 스폰하고 장착한다.
```
void ABSPickupItem::Interact(AActor* Interactor)
{
	if (EquipmentClass)
	{
		if (ABSEquipmentBase* CDO = EquipmentClass->GetDefaultObject<ABSEquipmentBase>())
		{
			if (ACharacter* Player = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0))
			{
				if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
				{
					if (CombatComp->GetMainWeapon() == nullptr || CombatComp->GetSecondaryWeapon() == nullptr)
					{
						FActorSpawnParameters Param;
						Param.Owner = Player;

						ABSEquipmentBase* Weapon = GetWorld()->SpawnActor<ABSEquipmentBase>(EquipmentClass, Player->GetActorTransform(), Param);
						if (Weapon)
						{
							Weapon->EquipItem();
						}
					}
					else
					{
						if (UBSInventoryComponent* InventoryComp = Player->GetComponentByClass<UBSInventoryComponent>())
						{
							InventoryComp->AddToSlot(CDO->GetInventoryInfo());
						}
					}
				}
			}
		}
	}

	Destroy();
}
```

<br>


Tab키와 바인딩 된 함수로 몽타주에 Notify를 넣어서 타이밍에 맞게 무기를 교체한다.
```
void ABSCharacterPlayer::ChangeWeapon()
{
	check(CombatComp);
	check(StateComp);

	if (CombatComp->CanChangeWeapon() && CanChangeWeapon())
	{
		if (UAnimMontage* UnequipMontage = CombatComp->GetMainWeapon()->GetMontageForTag(BSGameplayTag::Character_Action_Unequip))
		{
			StateComp->SetState(BSGameplayTag::Character_State_GeneralAction);

			PlayAnimMontage(UnequipMontage);
		}
	}
}
```

<br>

Unequip, Equip 애니메이션을 몽타주로 만들어서 Unequip 몽타주에서 무기를 집어 넣는 순간에! Equip 애니메이션 몽타주에서 무기를 꺼내는 순간으로 점프하여 자연스럽게 무기를 넣고 꺼내는 연출을 하고자 했다.

```
void UAnimNotify_BSWeaponEquip::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference)
{
	Super::Notify(MeshComp, Animation, EventReference);

	if (ACharacter* Player = Cast<ACharacter>(MeshComp->GetOwner()))
	{
		if (UAnimInstance* Anim = Player->GetMesh()->GetAnimInstance())
		{
			if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
			{
				if (ABSWeapon* Weapon = CombatComp->GetMainWeapon())
				{
					UAnimMontage* CurrentMontage = Anim->GetCurrentActiveMontage();
					float CurrentPosition = Anim->Montage_GetPosition(CurrentMontage);

					CombatComp->ChangeWeapon();

					Weapon = CombatComp->GetMainWeapon();

					UAnimMontage* NewMontage = Weapon->GetMontageForTag(BSGameplayTag::Character_Action_Equip);
					Anim->Montage_Play(NewMontage);
					Anim->Montage_SetPosition(NewMontage, CurrentPosition);
				}
			}
		}
	}
}
```

Unequip 애니메이션이 실행된 시간 만큼 Equip 애니메이션의 진행 시간을 옮긴다. 
그리고 CombatComponent 에서 Main 무기와 Secondary 무기를 서로 교체한다.

<br>


## 변경 파일 요약
- 주요 변경 파일과 역할을 간략히 정리합니다.
- AnimNotify_BSWeaponEquip - 무기 교체 타이밍 클래스 생성
- CombatComponent - 무기 교체 함수 추가 

<br>


## 궁금한 점 / 공부가 더 필요한 부분
- 작업 중 발생한 궁금한 점, 또는 이해가 잘 안되는 부분을 정리합니다.

타이밍에 딱 맞는 Unequip과 Equip 애니메이션이 있다면 더 깔끔히 작업할 수 있을 것 같다...